### PR TITLE
Test + code to copy properties from the old function to wrapped function

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 require('./index.js');
 const express = require('express');
 const supertest = require('supertest');
+const assert = require('assert');
 
 describe('express-async-errors', () => {
   it('propagates routes errors to error handler', () => {
@@ -31,7 +32,6 @@ describe('express-async-errors', () => {
       throw new Error('error');
     });
 
-
     app.use((err, req, res, next) => {
       res.status(495);
       res.end();
@@ -61,5 +61,49 @@ describe('express-async-errors', () => {
     return supertest(app)
       .get('/test')
       .expect(495);
+  });
+
+  it('should preserve the router stack for external routes', () => {
+    const app = express();
+
+    function swaggerize(item) {
+      function describeRouterRoute(router, metaData) {
+        const lastRoute = router.stack[router.stack.length - 1];
+        const verb = Object.keys(lastRoute.route.methods)[0];
+        metaData.path = lastRoute.route.path;
+        metaData.verb = verb;
+        lastRoute.route.swaggerData = metaData;
+        metaData.described = true;
+      }
+
+      function describe(metaData) {
+        if (item.stack) {
+          describeRouterRoute(item, metaData);
+          return item;
+        }
+        describeRouterRoute(item._router, metaData);
+        return item;
+      }
+
+      item.describe = describe;
+    }
+
+    const router = express.Router();
+    swaggerize(router);
+
+    router
+      .get('/test', (req, res) => {
+        res.status(200).send('Ok');
+      })
+      .describe({ hasDescription: true });
+    app.use('/', router);
+
+    const appRouteStack = app._router.stack;
+    const someMiddlewareFunctionStack = appRouteStack[appRouteStack.length - 1];
+    const innerStack = someMiddlewareFunctionStack.handle.stack;
+    const routeData = innerStack[0].route.swaggerData;
+    assert.ok(routeData);
+    assert.equal(routeData.verb, 'get');
+    assert.equal(routeData.hasDescription, true);
   });
 });


### PR DESCRIPTION
Hey there

Someone who uses my library recently ran into an [issue with the two libraries working together](https://github.com/eXigentCoder/swagger-spec-express/issues/9). The reason for the issue is that when wrapping the existing function, the old properties on the function were not being copied across to the new function.

In this PR is a test that was failing before the code change and passing now as well as the code to copy the properties across.

Thanks a lot!