### PR TITLE
Handle param middleware errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,38 +1,33 @@
 const Layer = require('express/lib/router/layer');
 
-function copyOldProps(oldFn, newFn) {
+const last = arr => arr[arr.length - 1];
+const noop = Function.prototype;
+
+function copyFnProps(oldFn, newFn) {
   Object.keys(oldFn).forEach((key) => {
     newFn[key] = oldFn[key];
   });
-  return newFn;
 }
 
-function wrapErrorMiddleware(fn) {
-  const newFn = (err, req, res, next) => {
-    const ret = fn.call(this, err, req, res, next);
-
-    if (ret && ret.catch) {
-      ret.catch(innerErr => next(innerErr));
-    }
-
-    return ret;
-  };
-  return copyOldProps(fn, newFn);
+function preserveFnArity(oldFn, newFn) {
+  ['name', 'length'].forEach((key) => {
+    Object.defineProperty(newFn, key, {
+      value: oldFn[key],
+      writable: false,
+    });
+  });
 }
 
 function wrap(fn) {
-  const newFn = (req, res, next) => {
-    const ret = fn.call(this, req, res, next);
-
-    if (ret && ret.catch) {
-      ret.catch((err) => {
-        next(err);
-      });
-    }
-
+  const newFn = (...args) => {
+    const ret = fn.apply(this, args);
+    const next = args.length > 2 ? last(args) : noop;
+    if (ret && ret.catch) ret.catch(err => next(err));
     return ret;
   };
-  return copyOldProps(fn, newFn);
+  copyFnProps(fn, newFn);
+  preserveFnArity(fn, newFn);
+  return newFn;
 }
 
 Object.defineProperty(Layer.prototype, 'handle', {
@@ -41,13 +36,7 @@ Object.defineProperty(Layer.prototype, 'handle', {
     return this.__handle;
   },
   set(fn) {
-    // Bizarre, but Express checks for 4 args to detect error middleware: https://github.com/expressjs/express/blob/master/lib/router/layer.js
-    if (fn.length === 4) {
-      fn = wrapErrorMiddleware(fn);
-    } else {
-      fn = wrap(fn);
-    }
-
+    fn = wrap(fn);
     this.__handle = fn;
   },
 });

--- a/index.js
+++ b/index.js
@@ -7,15 +7,7 @@ function copyFnProps(oldFn, newFn) {
   Object.keys(oldFn).forEach((key) => {
     newFn[key] = oldFn[key];
   });
-}
-
-function preserveFnArity(oldFn, newFn) {
-  ['name', 'length'].forEach((key) => {
-    Object.defineProperty(newFn, key, {
-      value: oldFn[key],
-      writable: false,
-    });
-  });
+  return newFn;
 }
 
 function wrap(fn) {
@@ -25,9 +17,11 @@ function wrap(fn) {
     if (ret && ret.catch) ret.catch(err => next(err));
     return ret;
   };
-  copyFnProps(fn, newFn);
-  preserveFnArity(fn, newFn);
-  return newFn;
+  Object.defineProperty(newFn, 'length', {
+    value: fn.length,
+    writable: false,
+  });
+  return copyFnProps(fn, newFn);
 }
 
 Object.defineProperty(Layer.prototype, 'handle', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,15 +1802,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1819,6 +1810,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test.js
+++ b/test.js
@@ -63,6 +63,28 @@ describe('express-async-errors', () => {
       .expect(495);
   });
 
+  it('and propagates param middleware errors too', () => {
+    const app = express();
+
+    app.param('id', async () => {
+      throw new Error('error');
+    });
+
+    app.get('/test/:id', async (err, req, next, id) => {
+      console.log(id);
+      throw new Error('error');
+    });
+
+    app.use((err, req, res, next) => {
+      res.status(495);
+      res.end();
+    });
+
+    return supertest(app)
+      .get('/test/12')
+      .expect(495);
+  });
+
   it('should preserve the router stack for external routes', () => {
     const app = express();
 


### PR DESCRIPTION
This PR aims to resolve #8 
- Common `wrap` function is added with function parity preservation to enable acceptance of an arbitrary number of params in wrapped middleware functions. This is possible cause of the fact that `next` is always the last argument. The only exception is `.param` middleware which is pinpointed by the only one having 5 arguments (`req`, `res`, `next`, `paramValue`, `paramName`).
- `Router.prototype.constructor.param` method is patched and middleware function is wrapped to catch errors
- Test for `.param` error handling is added