### PR TITLE
Prevent unhandled rejection warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ function copyFnProps(oldFn, newFn) {
 
 function wrap(fn) {
   const newFn = function newFn(...args) {
-    const ret = fn.apply(this, args);
     const next = (args.length === 5 ? args[2] : last(args)) || noop;
-    if (ret && ret.catch) ret.catch(err => next(err));
-    return ret;
+    return Promise.resolve()
+      .then(() => fn.apply(this, args))
+      .catch(err => next(err));
   };
   Object.defineProperty(newFn, 'length', {
     value: fn.length,


### PR DESCRIPTION
This change avoids an unhandled rejection warning that would otherwise
occur when `fn` is an async function that rejects on its first await.