### PR TITLE
Allow chaining of middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function wrap(fn) {
   const newFn = function newFn(...args) {
     const ret = fn.apply(this, args);
     const next = (args.length === 5 ? args[2] : last(args)) || noop;
+    if (ret && ret.then) ret.then(res => next(null, res));
     if (ret && ret.catch) ret.catch(err => next(err));
     return ret;
   };


### PR DESCRIPTION
As of now, successful resolution of one middleware doesn't pass control to a chained middleware like `router.get('/', middleware, anotherMiddleware). This commit enables that functionality which is also native to express.