### PR TITLE
Add two more express functionalities

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ function wrap(fn) {
   const newFn = function newFn(...args) {
     const ret = fn.apply(this, args);
     const next = (args.length === 5 ? args[2] : last(args)) || noop;
-    if (ret && ret.catch) ret.catch(err => next(err));
+    if (ret && ret.then) {
+      ret.then(
+        res => next(null, res),
+        err => next(err),
+      );
+    }
     return ret;
   };
   Object.defineProperty(newFn, 'length', {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function wrap(fn) {
     if (ret && ret.then) {
       ret.then(
         res => next(null, res),
-        err => next(err),
+        err => next(err.message === 'route' ? err.message : err),
       );
     }
     return ret;

--- a/test.js
+++ b/test.js
@@ -21,6 +21,33 @@ describe('express-async-errors', () => {
       .expect(495);
   });
 
+  it('propagates routes control to next route handler using next(\'route\')', () => {
+    const app = express();
+
+    app.get(
+      '/test',
+      async () => {
+        throw new Error('route');
+      },
+      async () => {
+        throw new Error('error');
+      },
+    );
+
+    app.get('/test*', async (req, res) => {
+      res.end();
+    });
+
+    app.use((err, req, res, next) => {
+      res.status(495);
+      res.end();
+    });
+
+    return supertest(app)
+      .get('/test')
+      .expect(200);
+  });
+
   it('propagates route control down a chain of routes', () => {
     const app = express();
 


### PR DESCRIPTION
As such, express-async-errors breaks certain express functionality that regular users are used to. This pull request aims to fill some of those gaps.

* `Allow chaining of route handlers` enables a chain of handlers instead of what is currently supported (just one):
```js
    app.get(
      '/test',
      handler1,
      handler2,
    );
```

* `Enable next('route') functionality by throwing new Error('route')` enables [bypassing the remaining handlers for the current route](https://github.com/expressjs/expressjs.com/blob/efcd571c9cbee9a4ceb07be6e3f732b2087d54bb/en/guide/routing.md#route-handlers)

### Tests
Added 3 more tests for the new functionality
![image](https://user-images.githubusercontent.com/10543509/64401820-317d7e80-d0a5-11e9-9d0d-f0be6fc9ecc8.png)
